### PR TITLE
fix for missing parentElement in IE on svg elements

### DIFF
--- a/closest.js
+++ b/closest.js
@@ -9,7 +9,7 @@
 				break;
 			}
 
-			element = element.parentElement;
+			element.parentNode instanceof Element ? element = element.parentNode : element = null;
 		}
 
 		return element;

--- a/closest.legacy.js
+++ b/closest.legacy.js
@@ -20,7 +20,7 @@
 				break;
 			}
 
-			element = element.parentElement;
+			element.parentNode instanceof Element ? element = element.parentNode : element = null;
 		}
 
 		return element;


### PR DESCRIPTION
In [IE up to and including IE 11](http://jsbin.com/redalovapa/edit?html,js,output) (but not in Edge), SVG elements (`<svg>` and their children) have no parentElement, only parentNode. So use parentNode, but check if they are elements (so documentElement doesn't match), which they still are in IE.