### PR TITLE
Reference Element as window.Element

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -90,7 +90,7 @@
 		"no-obj-calls": [2],
 		"no-octal-escape": [2],
 		"no-octal": [2],
-		"no-param-reassign": [2, { "props": true }],
+		"no-param-reassign": [2, { "props": false }],
 		"no-path-concat": [2],
 		"no-plusplus": [0],
 		"no-process-env": [2],

--- a/closest.js
+++ b/closest.js
@@ -1,21 +1,26 @@
 // element-closest | CC0-1.0 | github.com/jonathantneal/closest
-(function (Element) {
-	if (typeof Element.prototype.matches !== 'function') {
-		Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.webkitMatchesSelector || function matches(selector) {
-			var element = this;
-			var elements = (element.document || element.ownerDocument).querySelectorAll(selector);
-			var index = 0;
+(function (ElementProto) {
 
-			while (elements[index] && elements[index] !== element) {
-				++index;
-			}
+	if (typeof ElementProto.matches !== 'function') {
 
-			return Boolean(elements[index]);
-		};
+		ElementProto.matches = ElementProto.msMatchesSelector ||
+			ElementProto.mozMatchesSelector ||
+			ElementProto.webkitMatchesSelector ||
+			function matches(selector) {
+				var element = this;
+				var elements = (element.document || element.ownerDocument).querySelectorAll(selector);
+				var index = 0;
+
+				while (elements[index] && elements[index] !== element) {
+					++index;
+				}
+
+				return Boolean(elements[index]);
+			};
 	}
 
-	if (typeof Element.prototype.closest !== 'function') {
-		Element.prototype.closest = function closest(selector) {
+	if (typeof ElementProto.closest !== 'function') {
+		ElementProto.closest = function closest(selector) {
 			var element = this;
 
 			while (element && element.nodeType === 1) {
@@ -29,4 +34,5 @@
 			return null;
 		};
 	}
-})(window.Element);
+
+})(window.Element.prototype);

--- a/closest.js
+++ b/closest.js
@@ -1,5 +1,5 @@
 // element-closest | CC0-1.0 | github.com/jonathantneal/closest
-(function(Element) {
+(function (Element) {
 	if (typeof Element.prototype.matches !== 'function') {
 		Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.webkitMatchesSelector || function matches(selector) {
 			var element = this;

--- a/closest.js
+++ b/closest.js
@@ -1,31 +1,32 @@
 // element-closest | CC0-1.0 | github.com/jonathantneal/closest
+(function(Element) {
+	if (typeof Element.prototype.matches !== 'function') {
+		Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.webkitMatchesSelector || function matches(selector) {
+			var element = this;
+			var elements = (element.document || element.ownerDocument).querySelectorAll(selector);
+			var index = 0;
 
-if (typeof Element.prototype.matches !== 'function') {
-	Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.webkitMatchesSelector || function matches(selector) {
-		var element = this;
-		var elements = (element.document || element.ownerDocument).querySelectorAll(selector);
-		var index = 0;
-
-		while (elements[index] && elements[index] !== element) {
-			++index;
-		}
-
-		return Boolean(elements[index]);
-	};
-}
-
-if (typeof Element.prototype.closest !== 'function') {
-	Element.prototype.closest = function closest(selector) {
-		var element = this;
-
-		while (element && element.nodeType === 1) {
-			if (element.matches(selector)) {
-				return element;
+			while (elements[index] && elements[index] !== element) {
+				++index;
 			}
 
-			element = element.parentNode;
-		}
+			return Boolean(elements[index]);
+		};
+	}
 
-		return null;
-	};
-}
+	if (typeof Element.prototype.closest !== 'function') {
+		Element.prototype.closest = function closest(selector) {
+			var element = this;
+
+			while (element && element.nodeType === 1) {
+				if (element.matches(selector)) {
+					return element;
+				}
+
+				element = element.parentNode;
+			}
+
+			return null;
+		};
+	}
+})(window.Element);


### PR DESCRIPTION
This change wraps the polyfill in an IIFE that wraps `window.Element.prototype` in a closure, which fixes #16.