### PR TITLE
element-closest behaves as no-op in node environment

### DIFF
--- a/element-closest.js
+++ b/element-closest.js
@@ -1,4 +1,7 @@
 (function (ElementProto) {
+  if (!ElementProto) {
+    return;
+  }
 	if (typeof ElementProto.matches !== 'function') {
 		ElementProto.matches = ElementProto.msMatchesSelector || ElementProto.mozMatchesSelector || ElementProto.webkitMatchesSelector || function matches(selector) {
 			var element = this;
@@ -28,4 +31,4 @@
 			return null;
 		};
 	}
-})(window.Element.prototype);
+})(typeof window !== 'undefined' && window.Element.prototype);


### PR DESCRIPTION
At present:
```js
➜  closest git:(master) ✗ node
> require('./element-closest');
ReferenceError: window is not defined
    at Object.<anonymous> (/***/closest/element-closest.js:31:4)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at repl:1:1
    at ContextifyScript.Script.runInThisContext (vm.js:50:33)
>
```

Obviously this package polyfills a function that will only be present on the client, nevertheless I don't think it should blow up on require when executing in a node environment (if server-side rendering react, for example).

This PR means that you can run `require('element-closest')` in a node environment without problems.