### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "index.mjs",
     "index.mjs.map"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "npm run build:node && npm run build:browser",
     "build:node": "rollup --config",


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good for esm, modules, named imports.

ESM is how files and imports are organized, Side effects is how a bundler can remove obviously unused data from an assembly. Only both make maximum effect.

rollup https://rollupjs.org/configuration-options/#treeshake-modulesideeffects
webpack https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
esbuild https://esbuild.github.io/plugins/#on-resolve-arguments
